### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Only 5KB compressed and gzipped!
 API Reference
 =============
 
-###Table of contents
+### Table of contents
 
  - DOM traversal
     - [Dom.find](#domfindselector)
@@ -457,90 +457,90 @@ Determine whether a supplied listener is attached to the element
  - `event` a dom event name, eg. (`click`, `dblclick`, etc.)
  - `listener` a javascript callback function
 
-###DOM Events
+### DOM Events
 
 #### Mouse Events
 
-#####`click` Dom.onClick(`element|nodeList|Array`, `listener`)
+##### `click` Dom.onClick(`element|nodeList|Array`, `listener`)
 A pointing device button has been pressed and released on an element.
 
-#####`dblclick` Dom.onDblClick(`element|nodeList|Array`, `listener`)
+##### `dblclick` Dom.onDblClick(`element|nodeList|Array`, `listener`)
 A pointing device button is clicked twice on an element.
 
-#####`mouseover` Dom.onMouseOver(`element|nodeList|Array`, `listener`)
+##### `mouseover` Dom.onMouseOver(`element|nodeList|Array`, `listener`)
 A pointing device is moved onto the element that has the listener attached or onto one of its children.
 
-#####`mouseout` Dom.onMouseOut(`element|nodeList|Array`, `listener`)
+##### `mouseout` Dom.onMouseOut(`element|nodeList|Array`, `listener`)
 A pointing device is moved off the element that has the listener attached or off one of its children.
 
-#####`mousedown` Dom.onMouseOut(`element|nodeList|Array`, `listener`)
+##### `mousedown` Dom.onMouseOut(`element|nodeList|Array`, `listener`)
 A pointing device button (usually a mouse) is pressed on an element.
 
-#####`mouseup` Dom.onMouseUp(`element|nodeList|Array`, `listener`)
+##### `mouseup` Dom.onMouseUp(`element|nodeList|Array`, `listener`)
 A pointing device button is released over an element.
 
-#####`mouseenter` Dom.onMouseEnter(`element|nodeList|Array`, `listener`)
+##### `mouseenter` Dom.onMouseEnter(`element|nodeList|Array`, `listener`)
 A pointing device is moved onto the element that has the listener attached.
 
-#####`mouseleave` Dom.onMouseLeave(`element|nodeList|Array`, `listener`)
+##### `mouseleave` Dom.onMouseLeave(`element|nodeList|Array`, `listener`)
 A pointing device is moved off the element that has the listener attached.
 
-#####`mousemove` Dom.onMouseMove(`element|nodeList|Array`, `listener`)
+##### `mousemove` Dom.onMouseMove(`element|nodeList|Array`, `listener`)
 A pointing device is moved over an element.
 
 
 ### Form Events
 
-#####`focus` Dom.onFocus(`element|nodeList|Array`, `listener`)
+##### `focus` Dom.onFocus(`element|nodeList|Array`, `listener`)
 An element has received focus (does not bubble).
 
-#####`blur` Dom.onBlur(`element|nodeList|Array`, `listener`)
+##### `blur` Dom.onBlur(`element|nodeList|Array`, `listener`)
 An element has lost focus (does not bubble).
 
-#####`select` Dom.onSelect(`element|nodeList|Array`, `listener`)
+##### `select` Dom.onSelect(`element|nodeList|Array`, `listener`)
 Some text is input being selected.
 
-#####`change` Dom.onChange(`element|nodeList|Array`, `listener`)
+##### `change` Dom.onChange(`element|nodeList|Array`, `listener`)
 An element loses focus and its value changed since gaining focus.
 
-#####`submit` Dom.onSubmit`element|nodeList|Array`, `listener`)
+##### `submit` Dom.onSubmit`element|nodeList|Array`, `listener`)
 A form is submitted.
 
-#####`reset` Dom.onReset(`element|nodeList|Array`, `listener`)
+##### `reset` Dom.onReset(`element|nodeList|Array`, `listener`)
 A form is reset.
 
 ### Keyboard Events
 
-#####`keydown` Dom.onKeyDown(`element|nodeList|Array`, `listener`)
+##### `keydown` Dom.onKeyDown(`element|nodeList|Array`, `listener`)
 A key is pressed down.
 
-#####`keyup` Dom.onKeyUp(`element|nodeList|Array`, `listener`)
+##### `keyup` Dom.onKeyUp(`element|nodeList|Array`, `listener`)
 A key is released.
 
-#####`keypress` Dom.onKeyPress(`element|nodeList|Array`, `listener`)
+##### `keypress` Dom.onKeyPress(`element|nodeList|Array`, `listener`)
 A key is pressed down and that key normally produces a character value (use input instead).
 
 ### Drag Events
 
-#####`drag` Dom.onDrag(`element|nodeList|Array`, `listener`)
+##### `drag` Dom.onDrag(`element|nodeList|Array`, `listener`)
 An element or text selection is being dragged (every 350ms).
 
-#####`dragstart` Dom.onDragStart(`element|nodeList|Array`, `listener`)
+##### `dragstart` Dom.onDragStart(`element|nodeList|Array`, `listener`)
 The user starts dragging an element or text selection.
 
-#####`dragend` Dom.onDragEnd(`element|nodeList|Array`, `listener`)
+##### `dragend` Dom.onDragEnd(`element|nodeList|Array`, `listener`)
 A drag operation is being ended (by releasing a mouse button or hitting the escape key).
 
 ### UI Events
 
-#####`load` Dom.onLoad(`element|nodeList|Array`, `listener`)
+##### `load` Dom.onLoad(`element|nodeList|Array`, `listener`)
 A resource and its dependent resources have finished loading.
 
-#####`scroll` Dom.onScroll(`element|nodeList|Array`, `listener`)
+##### `scroll` Dom.onScroll(`element|nodeList|Array`, `listener`)
 The document view or an element has been scrolled.
 
-#####`unload` Dom.onUnload(`element|nodeList|Array`, `listener`)
+##### `unload` Dom.onUnload(`element|nodeList|Array`, `listener`)
 The document or a dependent resource is being unloaded.
 
-#####`resize` Dom.onResize(`element|nodeList|Array`, `listener`)
+##### `resize` Dom.onResize(`element|nodeList|Array`, `listener`)
 The document view has been resized.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
